### PR TITLE
Dev

### DIFF
--- a/commands/activity.js
+++ b/commands/activity.js
@@ -1,0 +1,32 @@
+const { roleStaff } = require('../config.json');
+
+module.exports = {
+	name: 'activity',
+	description: 'Change the bot\'s rich presence activity. If an activity type is not specified (or invalid) it will default to \'playing\'. Valid activity types are: \nPlaying \nListening \nWatching',
+	usage: '[activity type (optional)] [activity]',
+	cooldown: 3,
+	guildOnly: true,
+	staffOnly: true,
+	execute(message, args, client) {
+		if (!message.member.roles.has(roleStaff)) {
+			return;
+		}
+		const activitytype = args[0].toUpperCase();
+		if (activitytype === 'PLAYING' || activitytype === 'LISTENING' || activitytype === 'WATCHING') {
+			args.shift();
+			const activity = args.join(' ');
+			client.user.setActivity(activity, { type: activitytype });
+			if (activitytype === 'LISTENING') {message.channel.send ('I just started listening to **' + activity + '**. You should try it!');}
+			else {message.channel.send ('I just started ' + activitytype.toLowerCase() + ' **' + activity + '**. You should try it!');}
+			message.delete();
+			return;
+		}
+		else {
+			const activity = args.join(' ');
+			client.user.setActivity(activity, { type: 'PLAYING' });
+			message.channel.send ('I just started playing **' + activity + '**. You should try it!');
+			message.delete();
+			return;
+		}
+	},
+};

--- a/commands/hello.js
+++ b/commands/hello.js
@@ -1,0 +1,11 @@
+module.exports = {
+	name: 'hello',
+	aliases: ['ping', 'beep'],
+	description: 'Pings bot to verify operation',
+	cooldown: 3,
+	execute(message) {
+		const botguildmember = message.guild.me;
+		message.channel.send('Hello, I am ' + botguildmember.displayName + '.');
+		message.delete();
+	},
+};

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,4 @@
-const { prefix } = require('../config.json');
+const { prefix, roleStaff } = require('../config.json');
 
 module.exports = {
 	name: 'help',
@@ -9,10 +9,21 @@ module.exports = {
 	execute(message, args) {
 		const data = [];
 		const { commands } = message.client;
-		if (!args.length) {
+		// If the help invoker is staff, give all commands.
+		if (!args.length && message.member.roles.has(roleStaff)) {
 			data.push('Here\'s a list of all my commands:');
-			data.push(commands.map(command => command.name).join('\n'));
-			data.push(`\nYou can send \`${prefix}help [command name]\` to get info on a specific command!`);
+			// map all command names to an array, filter(Boolean) to remove empty values, then join for clean output
+			data.push(commands.map(command => command.name).filter(Boolean).join('\n'));
+			data.push(`You can send \`${prefix}help [command name]\` to get info on a specific command!`);
+
+			return message.channel.send(data, { split: true });
+		}
+		// If the invoker is not staff, but has permission to invoke the command, give only commands available to them.
+		if (!args.length && !message.member.roles.has(roleStaff)) {
+			data.push('Here\'s a list of commands available to you:');
+			// map all non-staffOnly command names to an array, filter(Boolean) to remove empty values, then join for clean output
+			data.push(commands.map(command => {if (!command.staffOnly) return command.name;}).filter(Boolean).join('\n'));
+			data.push(`You can send \`${prefix}help [command name]\` to get info on a specific command!`);
 
 			return message.channel.send(data, { split: true });
 		}

--- a/commands/help.js
+++ b/commands/help.js
@@ -30,8 +30,8 @@ module.exports = {
 		const name = args[0].toLowerCase();
 		const command = commands.get(name) || commands.find(c => c.aliases && c.aliases.includes(name));
 
-		if (!command) {
-			return message.reply('that\'s not a valid command!');
+		if (!command || (command.staffOnly && !message.member.roles.has(roleStaff))) {
+			return message.reply('that\'s not a valid command, or you don\'t have permission to use it!');
 		}
 
 		data.push(`**Name:** ${command.name}`);

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,9 +1,0 @@
-module.exports = {
-	name: 'ping',
-	aliases: ['ping', 'beep'],
-	description: 'Pings bot to verify operation',
-	cooldown: 3,
-	execute(message, args) {
-		message.channel.send('pong!');
-	},
-};

--- a/config example.json
+++ b/config example.json
@@ -1,4 +1,6 @@
 {
 	"prefix": "!",
-	"authtoken": ""
+	"authtoken": "",
+	"roleStaff": "",
+	"roleComrade": ""
 }


### PR DESCRIPTION
- enabled commands
- added a staffOnly property to commands that determines if they can be called by non-staff. the bot will ignore all commands that non-staff, non-comrades attempt.
- i added role IDs for staff and comrades to the config.json (**update your config.json using the example!**)
- i added a .activity command (staffOnly!) - call .help activity to see full details