### PR TITLE
add question command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -70,6 +70,7 @@ CONFIG_FILENAMES.forEach(filename => {
       freshConfig.disboardChannelId = '';
       freshConfig.eventInfoChannelId = '';
       freshConfig.pinIgnoreChannels = [];
+      freshConfig.questionChannelIds = [];
       freshConfig.voiceTextChannelIds = [];
       freshConfig.voiceChamberDefaultSizes = new Object();
       freshConfig.voiceChamberSnapbackDelay = '';

--- a/commands/question.js
+++ b/commands/question.js
@@ -1,0 +1,10 @@
+const {start} = require('thoughtful-question-generator')
+
+module.exports = {
+    name: 'question',
+    cooldown: 10,
+
+    execute(message) {
+        message.channel.send(start.evaluate())
+    },
+}

--- a/commands/question.js
+++ b/commands/question.js
@@ -4,7 +4,10 @@ module.exports = {
     name: 'question',
     cooldown: 10,
 
-    execute(message) {
-        message.channel.send(start.evaluate())
+    execute(message, _arguments, _client, config) {
+        // Are we allowed to respond in this channel?
+        if (config.questionChannelIds.includes(message.channel.id)) {
+            message.channel.send(start.evaluate())
+        }
     },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,6 +982,11 @@
       "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-1.2.0.tgz",
       "integrity": "sha512-ErTBd++b17E8nmWII1K1uZtBgD1E8RjyvwmxlCjPHNqHMD7gmcMHOw0E8Ro/6+QT4PhHRSnnMo7bxa1vFPkwhg=="
     },
+    "jen.js": {
+      "version": "git+ssh://git@github.com/HeladoDeBrownie/jen.js.git#492b95d57c3200e8fdb1cbf5babf45dbc6deed67",
+      "integrity": "sha512-aqmTxgOu1dXJbzutxB70eUWTz+ykClYs8Iu1+tVWZM48uRCpFUpBMRhotdEmGESbTT6RgDgDGeYh6z+KlslEKw==",
+      "from": "jen.js@github:HeladoDeBrownie/jen.js#492b95d57c3200e8fdb1cbf5babf45dbc6deed67"
+    },
     "jszip": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
@@ -1730,6 +1735,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "thoughtful-question-generator": {
+      "version": "git+ssh://git@github.com/HeladoDeBrownie/Thoughtful-Question-Generator.git#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
+      "integrity": "sha512-vE21XCg2F57qHaByW6L2RPayAKo4pD2sUAl7y7srdKHagHvAaLxyZJx1trVHhYlgJccoivKLGX3JtXhnF4qL3A==",
+      "from": "thoughtful-question-generator@github:HeladoDeBrownie/Thoughtful-Question-Generator#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
+      "requires": {
+        "jen.js": "github:HeladoDeBrownie/jen.js#492b95d57c3200e8fdb1cbf5babf45dbc6deed67"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "moment-timezone": "^0.5.32",
     "node-fetch": "^2.6.1",
     "simple-youtube-api": "^5.2.1",
+    "thoughtful-question-generator": "github:HeladoDeBrownie/Thoughtful-Question-Generator#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
     "ytdl": "^1.4.1",
     "ytdl-core": "^4.4.5"
   },


### PR DESCRIPTION
this patch adds the `.question` command, which can be triggered by any user to randomly generate/select a thought-provoking question

this adds a direct dependency on my [thoughtful question generator](https://github.com/HeladoDeBrownie/Thoughtful-Question-Generator/tree/b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3) repository at a specific commit, and an indirect dependency on my [jen.js](https://github.com/HeladoDeBrownie/jen.js/tree/492b95d57c3200e8fdb1cbf5babf45dbc6deed67) library. the bot module itself is just a thin wrapper for the generator