### PR TITLE
add question command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -71,6 +71,7 @@ CONFIG_FILENAMES.forEach(filename => {
       freshConfig.eventInfoChannelId = '';
       freshConfig.pinIgnoreChannels = [];
       freshConfig.pinsToPin = 5;
+      freshConfig.questionChannelIds = [];
       freshConfig.voiceTextChannelIds = [];
       freshConfig.voiceChamberDefaultSizes = new Object();
       freshConfig.voiceChamberSnapbackDelay = '';

--- a/commands/question.js
+++ b/commands/question.js
@@ -1,0 +1,10 @@
+const {start} = require('thoughtful-question-generator')
+
+module.exports = {
+    name: 'question',
+    cooldown: 10,
+
+    execute(message, _arguments, _client, config) {
+        message.channel.send(start.evaluate())
+    },
+}

--- a/commands/question.js
+++ b/commands/question.js
@@ -5,6 +5,9 @@ module.exports = {
     cooldown: 10,
 
     execute(message, _arguments, _client, config) {
-        message.channel.send(start.evaluate())
+        // Are we allowed to respond in this channel?
+        if (config.questionChannelIds.includes(message.channel.id)) {
+            message.channel.send(start.evaluate())
+        }
     },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "optional": true
     },
+    "jen.js": {
+      "version": "git+ssh://git@github.com/HeladoDeBrownie/jen.js.git#492b95d57c3200e8fdb1cbf5babf45dbc6deed67",
+      "integrity": "sha512-aqmTxgOu1dXJbzutxB70eUWTz+ykClYs8Iu1+tVWZM48uRCpFUpBMRhotdEmGESbTT6RgDgDGeYh6z+KlslEKw==",
+      "from": "jen.js@github:HeladoDeBrownie/jen.js#492b95d57c3200e8fdb1cbf5babf45dbc6deed67"
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2179,6 +2184,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "thoughtful-question-generator": {
+      "version": "git+ssh://git@github.com/HeladoDeBrownie/Thoughtful-Question-Generator.git#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
+      "integrity": "sha512-vE21XCg2F57qHaByW6L2RPayAKo4pD2sUAl7y7srdKHagHvAaLxyZJx1trVHhYlgJccoivKLGX3JtXhnF4qL3A==",
+      "from": "thoughtful-question-generator@github:HeladoDeBrownie/Thoughtful-Question-Generator#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
+      "requires": {
+        "jen.js": "github:HeladoDeBrownie/jen.js#492b95d57c3200e8fdb1cbf5babf45dbc6deed67"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "simple-youtube-api": "^5.2.1",
     "sqlite": "^4.0.19",
     "sqlite3": "^5.0.2",
+    "thoughtful-question-generator": "github:HeladoDeBrownie/Thoughtful-Question-Generator#b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3",
     "ytdl": "^1.4.1",
     "ytdl-core": "^4.4.5"
   },


### PR DESCRIPTION
this is to replace #49 since that pr was based on the wrong branch. quoting from there:

> this patch adds the `.question` command, which can be triggered by any user to randomly generate/select a thought-provoking question
> 
> this adds a direct dependency on my [thoughtful question generator](https://github.com/HeladoDeBrownie/Thoughtful-Question-Generator/tree/b47e03059d1a00601e4ad8c02ebfdac8dd4bf9c3) repository at a specific commit, and an indirect dependency on my [jen.js](https://github.com/HeladoDeBrownie/jen.js/tree/492b95d57c3200e8fdb1cbf5babf45dbc6deed67) library. the bot module itself is just a thin wrapper for the generator