### PR TITLE
Fix errors when DMing bot + unify permission checks

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -119,6 +119,7 @@ if (fs.existsSync(eventDataPath)) { global.eventData = require(eventDataPath);}
 const moment = require('moment-timezone');
 const vettingLimitPath = './commands/vettinglimit.js';
 const starboard = require('./starboard.js');
+const {getPermLevel} = require('./extras/common.js');
 
 // Extend guild with music details accessed by the .yt command.
 Discord.Structures.extend('Guild', Guild => {
@@ -192,29 +193,6 @@ Discord.Structures.extend('Message', Message => {
   }
   return PKMessage;
 });
-
-// function to determine if a user's permission level - returns null, 'comrade', or 'staff'
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
 
 // initialize client, commands, command cooldown collections
 myIntents.add(Discord.Intents.NON_PRIVILEGED, 'GUILD_MEMBERS');

--- a/commands/games.js
+++ b/commands/games.js
@@ -5,28 +5,7 @@ const config = require(configPath);
 const listPath = path.resolve('./gamelist.json');
 const gameList = require(listPath);
 const Discord = require('discord.js');
-
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
+const {getPermLevel} = require('../extras/common.js');
 
 module.exports = {
   name: 'games',

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,28 +1,7 @@
 const path = require('path');
 const configPath = path.resolve('./config.json');
 const config = require(configPath);
-
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
+const {getPermLevel} = require('../extras/common.js');
 
 module.exports = {
   name: 'help',

--- a/commands/star.js
+++ b/commands/star.js
@@ -4,28 +4,7 @@ const starboard = require(starboardpath);
 const configPath = path.resolve('./config.json');
 const config = require(configPath);
 const fs = require('fs');
-
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
+const {getPermLevel} = require('../extras/common.js');
 
 function prettyPrintConfig() {
   const output = JSON.stringify(config, function(k, v) {

--- a/commands/vc.js
+++ b/commands/vc.js
@@ -2,28 +2,7 @@ const path = require('path');
 const configPath = path.resolve('./config.json');
 const config = require(configPath);
 const wait = require('util').promisify(setTimeout);
-
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
+const {getPermLevel} = require('../extras/common.js');
 
 async function updateChannel(type, args, message) {
   const permLevel = getPermLevel(message);

--- a/commands/yt.js
+++ b/commands/yt.js
@@ -8,33 +8,13 @@ const path = require('path');
 const configPath = path.resolve('./config.json');
 const config = require(configPath);
 const wait = require('util').promisify(setTimeout);
+const {getPermLevel} = require('../extras/common.js');
+
 let YT;
 if (!config.youTubeAPIKey) {
   console.log('No youtube API Key set! until it is set by editing config.json, the YT voice features will not work.');
 }
 else { YT = new YouTube(config.youTubeAPIKey); }
-
-function getPermLevel(message) {
-  if (message.isPKMessage) {
-    if (message.PKData.author.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  else if (!message.isPKMessage) {
-    if (message.member.roles.cache.has(config.roleStaff)) {
-      return 'staff';
-    }
-    else if (message.member.roles.cache.has(config.roleComrade)) {
-      return 'comrade';
-    }
-    else {return null;}
-  }
-  return null;
-}
 
 module.exports = {
   name: 'yt',

--- a/extras/common.js
+++ b/extras/common.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const configPath = path.resolve('./config.json');
+const config = require(configPath);
+const Discord = require('discord.js');
+
+// function to determine if a user's permission level - returns null, 'comrade', or 'staff'
+function getPermLevel(message) {
+    if (message.channel instanceof Discord.DMChannel) return null;
+
+    if (message.isPKMessage) {
+        if (message.PKData.author.roles.cache.has(config.roleStaff)) {
+            return 'staff';
+        }
+        else if (message.PKData.author.roles.cache.has(config.roleComrade)) {
+            return 'comrade';
+        }
+        else {return null;}
+    }
+    else if (!message.isPKMessage) {
+        if (message.member.roles.cache.has(config.roleStaff)) {
+            return 'staff';
+        }
+        else if (message.member.roles.cache.has(config.roleComrade)) {
+            return 'comrade';
+        }
+        else {return null;}
+    }
+    return null;
+}
+
+module.exports = {
+    getPermLevel,
+};


### PR DESCRIPTION
Extracts the `getPermLevel` function out to a separate file and adds a DM check which bypasses role/PK checks as these aren't applicable to DMs.